### PR TITLE
Add action to automatically build and publish the image

### DIFF
--- a/.github/workflows/update_quay_image.yml
+++ b/.github/workflows/update_quay_image.yml
@@ -1,0 +1,35 @@
+name: ContainerImage
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build_container:
+    name: Update FedoraPeopleRepos container image on Quay.
+    runs-on: ubuntu-latest
+    if: github.repository == 'SatelliteQE/fedorapeople-repos'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.QUAY_SERVER }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push image to Quay
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.QUAY_SERVER }}/${{ secrets.QUAY_NAMESPACE }}/fedorapeople-repos:latest


### PR DESCRIPTION
This action will build the image and push to our Quay account. This will allow us to less directly depend on DockeHub.